### PR TITLE
Add Python 3.6, drop Python 3.3

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,8 @@
+[run]
+source = zope.dublincore
+
+[report]
+exclude_lines =
+    pragma: no cover
+    if __name__ == '__main__':
+    raise NotImplementedError

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ python:
     - 3.5
     - 3.6
     - pypy-5.6.0
-    - pypy3.3-5.5-alpha
 install:
     - pip install -U pip setuptools
     - pip install -U coverage coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,22 @@ language: python
 sudo: false
 python:
     - 2.7
-    - 3.3
     - 3.4
     - 3.5
-    - pypy
-    - pypy3
+    - 3.6
+    - pypy-5.6.0
+    - pypy3.3-5.5-alpha
 install:
-    - pip install .
-    - pip install zope.dublincore[test]
+    - pip install -U pip setuptools
+    - pip install -U coverage coveralls
+    - pip install -U -e .[test,docs]
 script:
-    - python setup.py -q test -q
+    - coverage run -m zope.testrunner --test-path=src
+    - coverage run -a -m sphinx -b doctest -d docs/_build/doctrees docs docs/_build/doctest
+after_success:
+    - coveralls
 notifications:
     email: false
+cache: pip
+before_cache:
+    - rm -f $HOME/.cache/pip/log/debug.log

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,13 +4,12 @@ Changes
 4.2.0 (Unreleased)
 ------------------
 
-- Add support for Python 3.5.
+- Add support for Python 3.5 and 3.6.
 
-- Drop support for Python 2.6.
+- Drop support for Python 2.6 and 3.3.
 
 - Convert doctests to Sphinx, including building docs and testing doctest
   snippets under ``tox``.
-
 
 
 4.1.1 (2014-01-10)

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,7 +3,14 @@ include *.txt
 include bootstrap.py
 include buildout.cfg
 include tox.ini
+include .travis.yml
+include .coveragerc
 
 recursive-include src *
+
+recursive-include docs *.bat
+recursive-include docs *.py
+recursive-include docs *.rst
+recursive-include docs Makefile
 
 global-exclude *.pyc

--- a/README.rst
+++ b/README.rst
@@ -1,16 +1,25 @@
 ``zope.dublincore``
 ===================
 
-.. image:: https://pypip.in/version/zope.dublincore/badge.svg?style=flat
-    :target: https://pypi.python.org/pypi/zope.dublincore/
-    :alt: Latest Version
+.. image:: https://img.shields.io/pypi/v/zope.dublincore.svg
+   :target: https://pypi.python.org/pypi/zope.dublincore/
+   :alt: Latest release
+
+.. image:: https://img.shields.io/pypi/pyversions/zope.dublincore.svg
+   :target: https://pypi.org/project/zope.dublincore/
+   :alt: Supported Python versions
 
 .. image:: https://travis-ci.org/zopefoundation/zope.dublincore.png?branch=master
-        :target: https://travis-ci.org/zopefoundation/zope.dublincore
+   :target: https://travis-ci.org/zopefoundation/zope.dublincore
 
 .. image:: https://readthedocs.org/projects/zopedublincore/badge/?version=latest
-        :target: http://zopedublincore.readthedocs.org/en/latest/
-        :alt: Documentation Status
+   :target: http://zopedublincore.readthedocs.org/en/latest/
+   :alt: Documentation Status
+
+.. image:: https://coveralls.io/repos/github/zopefoundation/zope.dublincore/badge.svg?branch=master
+   :target: https://coveralls.io/github/zopefoundation/zope.dublincore?branch=master
+   :alt: Code Coverage
+
 
 This package provides a Dublin Core support for Zope-based web
 applications.  This includes:
@@ -29,3 +38,5 @@ applications.  This includes:
 
 * subscribers to various object lifecycle events that automatically
   set the created and modified date and some other metadata.
+
+Complete documentation is hosted at https://zopedublincore.readthedocs.io/

--- a/docs/narrative.rst
+++ b/docs/narrative.rst
@@ -31,16 +31,16 @@ by simply defining a property as DCProperty.
    ...     authors = property.DCListProperty('creators')
    >>> obj = DC()
    >>> obj.title = u'My title'
-   >>> obj.title
-   u'My title'
+   >>> print(obj.title)
+   My title
 
 Let's see if the title is really stored in dublin core:
 
 .. doctest::
 
    >>> from zope.dublincore.interfaces import IZopeDublinCore
-   >>> IZopeDublinCore(obj).title
-   u'My title'
+   >>> print(IZopeDublinCore(obj).title)
+   My title
 
 Even if a dublin core property is a list property we can set and get the
 property as scalar type:
@@ -48,20 +48,20 @@ property as scalar type:
 .. doctest::
 
    >>> obj.author = u'me'
-   >>> obj.author
-   u'me'
+   >>> print(obj.author)
+   me
 
 DCListProperty acts on the list:
 
 .. doctest::
 
-   >>> obj.authors
-   (u'me',)
+   >>> obj.authors == (u'me',)
+   True
    >>> obj.authors = [u'I', u'others']
-   >>> obj.authors
-   (u'I', u'others')
-   >>> obj.author
-   u'I'
+   >>> obj.authors == (u'I', u'others')
+   True
+   >>> print(obj.author)
+   I
 
 
 Dublin Core metadata as content data
@@ -117,12 +117,12 @@ object, the value stored on the content object is used:
    >>> content = Content()
    >>> adapter = factory(content)
 
-   >>> adapter.title
-   u''
+   >>> print(adapter.title)
+   <BLANKLINE>
 
    >>> content.title = u'New Title'
-   >>> adapter.title
-   u'New Title'
+   >>> print(adapter.title)
+   New Title
 
 If we set the relevant Dublin Core field using the adapter, the
 content object is updated:
@@ -130,8 +130,8 @@ content object is updated:
 .. doctest::
 
    >>> adapter.title = u'Adapted Title'
-   >>> content.title
-   u'Adapted Title'
+   >>> print(content.title)
+   Adapted Title
 
 Dublin Core fields which are not specifically mapped to the content
 object do not affect the content object:
@@ -139,10 +139,10 @@ object do not affect the content object:
 .. doctest::
 
    >>> adapter.description = u"Some long description."
-   >>> content.description
-   u''
-   >>> adapter.description
-   u'Some long description.'
+   >>> print(content.description)
+   <BLANKLINE>
+   >>> print(adapter.description)
+   Some long description.
 
 
 Using arbitrary field names
@@ -182,16 +182,16 @@ We can check the effects of the adapter as before:
    >>> content = Content()
    >>> adapter = factory(content)
 
-   >>> adapter.description
-   u''
+   >>> print(adapter.description)
+   <BLANKLINE>
 
    >>> content.abstract = u"What it's about."
-   >>> adapter.description
-   u"What it's about."
+   >>> print(adapter.description)
+   What it's about.
 
    >>> adapter.description = u'Change of plans.'
-   >>> content.abstract
-   u'Change of plans.'
+   >>> print(content.abstract)
+   Change of plans.
 
 
 Limitations

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,3 +9,6 @@ ignore-files=examples.py
 [aliases]
 dev = develop easy_install zope.dublincore[testing]
 docs = easy_install zope.dublincore[docs]
+
+[bdist_wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,8 @@ from setuptools import setup, find_packages
 import os.path
 
 def read(*path):
-    return open(os.path.join(*path)).read() + '\n\n'
+    with open(os.path.join(*path)) as f:
+        return f.read() + '\n\n'
 
 def alltests():
     import os
@@ -48,17 +49,19 @@ tests_require = [
     'zope.testing >= 3.8',
     'zope.testrunner',
     'zope.configuration',
-    ]
+    'BTrees',
+]
 
 setup(
     name="zope.dublincore",
     version='4.2.0.dev0',
-    url='http://pypi.python.org/pypi/zope.dublincore',
+    url='http://github.com/zopefoundation/zope.dublincore',
     license='ZPL 2.1',
     description='Zope Dublin Core implementation',
     long_description=long_description,
     author='Zope Foundation and Contributors',
     author_email='zope-dev@zope.org',
+    keywords='metadata dublincore',
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
@@ -69,20 +72,19 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Software Development',
-        ],
-
+    ],
     packages=find_packages('src'),
-    package_dir={'':'src'},
+    package_dir={'': 'src'},
     namespace_packages=['zope'],
     include_package_data=True,
-    install_requires = [
+    install_requires=[
         'persistent',
         'pytz',
         'setuptools',
@@ -95,13 +97,13 @@ setup(
         'zope.location',
         'zope.schema',
         'zope.security[zcml]>=3.8',
-        ],
-    test_suite = '__main__.alltests',
-    tests_require = tests_require,
-    extras_require = {
+    ],
+    test_suite='__main__.alltests',
+    tests_require=tests_require,
+    extras_require={
         'testing': tests_require,
         'test': tests_require,
         'docs': ['Sphinx', 'repoze.sphinx.autointerface'],
     },
-    zip_safe = False
-    )
+    zip_safe=False,
+)

--- a/tox.ini
+++ b/tox.ini
@@ -1,39 +1,26 @@
 [tox]
 envlist =
-    py27,py33,py34,py35,pypy,pypy3,coverage,docs
+    py27,py34,py35,py36,pypy,pypy3,docs
 
 [testenv]
 commands =
-    python setup.py -q test -q
-# without explicit deps, setup.py test will download a bunch of eggs into $PWD
-# (and it seems I can't use zope.dottedname[testing] here, so forget DRY)
+    zope-testrunner --test-path=src []
+    sphinx-build -b doctest -d {envdir}/.cache/doctrees docs {envdir}/.cache/doctest
 deps =
-    persistent
-    pytz
-    six
-    zope.annotation
-    zope.component[zcml]
-    zope.configuration
-    zope.datetime
-    zope.interface
-    zope.lifecycleevent
-    zope.location
-    zope.schema
-    zope.security[zcml]
-    zope.testing
-    zope.testrunner
+    .[test,docs]
 
 [testenv:coverage]
 usedevelop = true
 basepython =
     python2.7
-commands = 
-    nosetests --with-xunit --with-xcoverage
+commands =
+    coverage run -m zope.testrunner --test-path=src []
+    coverage run -a -m sphinx -b doctest -d {envdir}/.cache/doctrees docs {envdir}/.cache/doctest
+    coverage report
 deps =
     {[testenv]deps}
-    nose
     coverage
-    nosexcover
+
 
 [testenv:docs]
 basepython =
@@ -41,7 +28,3 @@ basepython =
 commands =
     sphinx-build -b html -d docs/_build/doctrees docs docs/_build/html
     sphinx-build -b doctest -d docs/_build/doctrees docs docs/_build/doctest
-deps =
-    {[testenv]deps}
-    Sphinx
-    repoze.sphinx.autointerface


### PR DESCRIPTION
Also be sure that the doctests are run on CI and in tox. Make them work for all versions of Python.

Use modern badge locations in README.rst since the old one was broken.

Refs zopefoundation/zopetoolkit#8

NOTE: TravisCI is having issues installing some Python versions right now (the S3 bucket permissions seem to be incorrect). So some of the builds will probably fail initially. I got the same errors with both precise and trusty, albeit on different versions of Python.