### PR TITLE
Drop support for Python 3.4 and 3.5.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ sudo: false
 python:
     - 2.7
     - 3.6
-    - pypy-5.6.0
+    - pypy
+    - pypy3
 install:
     - pip install -U pip setuptools
     - pip install -U coverage coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: python
 sudo: false
 python:
     - 2.7
-    - 3.4
-    - 3.5
     - 3.6
     - pypy-5.6.0
 install:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changes
 4.2.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Drop support for Python 3.4 and 3.5.
 
 
 4.2.0 (2017-07-25)

--- a/setup.py
+++ b/setup.py
@@ -72,8 +72,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py27,py34,py35,py36,pypy,pypy3,docs
+    py27,py36,pypy,pypy3,docs
 
 [testenv]
 commands =


### PR DESCRIPTION
This PR only exists to make TravisCI green again.

Support for new Python versions is added later on.