### PR TITLE
Switch to PEP 420 native namespace.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changes
 6.0 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Replace ``pkg_resources`` namespace with PEP 420 native namespace.
 
 
 5.1 (2025-06-26)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 Changes
 =======
 
-5.2 (unreleased)
+6.0 (unreleased)
 ----------------
 
 - Nothing changed yet.

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ tests_require = testing_require + [
 
 setup(
     name="zope.dublincore",
-    version='5.2.dev0',
+    version='6.0.dev0',
     url='http://github.com/zopefoundation/zope.dublincore',
     license='ZPL-2.1',
     description='Zope Dublin Core implementation',

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@
 """
 import os.path
 
-from setuptools import find_packages
 from setuptools import setup
 
 
@@ -36,7 +35,7 @@ long_description = '\n\n'.join([
 
 testing_require = [
     'zope.testing >= 3.8',
-    'zope.testrunner',
+    'zope.testrunner >= 6.4',
     'zope.configuration',
     'BTrees',
 ]
@@ -74,9 +73,6 @@ setup(
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Software Development',
     ],
-    packages=find_packages('src'),
-    package_dir={'': 'src'},
-    namespace_packages=['zope'],
     include_package_data=True,
     python_requires='>=3.9',
     install_requires=[

--- a/src/zope/__init__.py
+++ b/src/zope/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)


### PR DESCRIPTION
- **Bumped version for breaking release.**
- **Replace ``pkg_resources`` namespace with PEP 420 native namespace.**
- **Switch to PEP 420 native namespace.**
